### PR TITLE
fix: use ImportError and context managers for file reads

### DIFF
--- a/fastgen/callbacks/wandb.py
+++ b/fastgen/callbacks/wandb.py
@@ -91,7 +91,8 @@ def init_wandb(config: BaseConfig):
     # wandb login
     wandb_credential = config.log_config.wandb_credential
     if os.path.isfile(wandb_credential):
-        os.environ["WANDB_API_KEY"] = open(wandb_credential, encoding="utf-8").read().strip("\n")
+        with open(wandb_credential, encoding="utf-8") as f:
+            os.environ["WANDB_API_KEY"] = f.read().strip("\n")
         logger.info(f"Loading WANDB_API_KEY from {wandb_credential}")
 
     wandb_config = config.log_config
@@ -101,7 +102,8 @@ def init_wandb(config: BaseConfig):
     os.makedirs(wandb_config.save_path, exist_ok=True)
     wandb_id_path = f"{wandb_config.save_path}/wandb_id.txt"
     if os.path.isfile(wandb_id_path):
-        wandb_id = open(wandb_id_path, encoding="utf-8").read().strip()
+        with open(wandb_id_path, encoding="utf-8") as f:
+            wandb_id = f.read().strip()
         logger.info(f"Resuming with an existing wandb id: {wandb_id}")
     else:
         wandb_id = wandb.util.generate_id()

--- a/fastgen/third_party/wan_prompt_expand/prompt_expand.py
+++ b/fastgen/third_party/wan_prompt_expand/prompt_expand.py
@@ -262,7 +262,7 @@ class QwenPromptExpander(PromptExpander):
             )
             try:
                 from .qwen_vl_utils import process_vision_info
-            except:
+            except ImportError:
                 from qwen_vl_utils import process_vision_info
             self.process_vision_info = process_vision_info
             min_pixels = 256 * 28 * 28


### PR DESCRIPTION
- `prompt_expand.py`: bare `except:` → `except ImportError:`
- `wandb.py`: 2x `open().read()` → `with open() as f:` to prevent file descriptor leaks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of saved authentication and session information by ensuring files are properly closed after reading.
  * Refined fallback behavior when loading optional prompt-processing functionality, improving reliability without changing expected results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->