### PR TITLE
Use fake_score features for DMD2 discriminator losses

### DIFF
--- a/fastgen/methods/distribution_matching/dmd2.py
+++ b/fastgen/methods/distribution_matching/dmd2.py
@@ -121,39 +121,34 @@ class DMD2Model(FastGenModel):
         eps = torch.randn_like(real_data, device=self.device, dtype=real_data.dtype)
         return input_student, t_student, t, eps
 
-    def _compute_teacher_prediction_gan_loss(
+    def _compute_teacher_x0(
         self, perturbed_data: torch.Tensor, t: torch.Tensor, condition: Optional[Any] = None
-    ) -> tuple[torch.Tensor, torch.Tensor]:
-        """Compute teacher prediction and optionally GAN loss for generator.
-
-        Args:
-            perturbed_data: Perturbed data tensor
-            t: Time steps
-            condition: Conditioning information
-
-        Returns:
-            tuple of (teacher_x0, fake_feat or None, gan_loss_gen)
-        """
-        if self.config.gan_loss_weight_gen > 0:
-            teacher_x0, fake_feat = self.teacher(
-                perturbed_data,
-                t,
-                condition=condition,
-                feature_indices=self.discriminator.feature_indices,
-                fwd_pred_type="x0",
-            )
-            # Compute the GAN loss for the generator
-            gan_loss_gen = gan_loss_generator(self.discriminator(fake_feat))
-        else:
+    ) -> torch.Tensor:
+        """Compute the teacher x0 target used by VSD."""
+        with torch.no_grad():
             teacher_x0 = self.teacher(
                 perturbed_data,
                 t,
                 condition=condition,
                 fwd_pred_type="x0",
             )
-            gan_loss_gen = torch.tensor(0.0, device=self.device, dtype=teacher_x0.dtype)
+        return teacher_x0.detach()
 
-        return teacher_x0.detach(), gan_loss_gen
+    def _compute_generator_gan_loss(
+        self, perturbed_data: torch.Tensor, t: torch.Tensor, condition: Optional[Any] = None
+    ) -> torch.Tensor:
+        """Compute the generator-side GAN loss from fake_score features."""
+        if self.config.gan_loss_weight_gen <= 0:
+            return torch.tensor(0.0, device=self.device, dtype=perturbed_data.dtype)
+
+        fake_feat = self.fake_score(
+            perturbed_data,
+            t,
+            condition=condition,
+            return_features_early=True,
+            feature_indices=self.discriminator.feature_indices,
+        )
+        return gan_loss_generator(self.discriminator(fake_feat))
 
     def _apply_classifier_free_guidance(
         self,
@@ -223,7 +218,8 @@ class DMD2Model(FastGenModel):
         assert (
             t.dtype == t_student.dtype == self.net.noise_scheduler.t_precision
         ), f"t.dtype: {t.dtype}, t_student.dtype: {t_student.dtype}, self.net.noise_scheduler.t_precision: {self.net.noise_scheduler.t_precision}"
-        teacher_x0, gan_loss_gen = self._compute_teacher_prediction_gan_loss(perturbed_data, t, condition=condition)
+        teacher_x0 = self._compute_teacher_x0(perturbed_data, t, condition=condition)
+        gan_loss_gen = self._compute_generator_gan_loss(perturbed_data, t, condition=condition)
 
         # Apply classifier-free guidance if needed
         if self.config.guidance_scale is not None:
@@ -250,7 +246,7 @@ class DMD2Model(FastGenModel):
     def _compute_real_feat(
         self, real_data: torch.Tensor, t: torch.Tensor, eps: torch.Tensor, condition: Optional[Any] = None
     ) -> tuple[torch.Tensor, torch.Tensor]:
-        """Compute discriminator features for both real and fake data.
+        """Compute real features for the discriminator using the fake_score backbone.
 
         Args:
             real_data: Real data tensor
@@ -272,9 +268,8 @@ class DMD2Model(FastGenModel):
                 device=self.device,
             )
             eps_real = torch.randn_like(real_data)
-        # Perturb the real data according to the given forward process
         perturbed_real = self.net.noise_scheduler.forward_process(real_data, eps_real, t_real)
-        real_feat = self.teacher(
+        real_feat = self.fake_score(
             perturbed_real,
             t_real,
             condition=condition,
@@ -304,7 +299,7 @@ class DMD2Model(FastGenModel):
         """
         perturbed_real_alpha = real_data.add(self.config.gan_r1_reg_alpha * torch.randn_like(real_data))
         with torch.no_grad():
-            real_feat_alpha = self.teacher(
+            real_feat_alpha = self.fake_score(
                 perturbed_real_alpha,
                 t_real,
                 condition=condition,
@@ -365,16 +360,14 @@ class DMD2Model(FastGenModel):
         gan_loss_ar1 = torch.zeros_like(loss_fakescore)
         if self.config.gan_loss_weight_gen > 0:
             # Compute the GAN loss for the discriminator
-            with torch.no_grad():
-                fake_feat = self.teacher(
-                    x_t_sg,
-                    t,
-                    condition=condition,
-                    return_features_early=True,
-                    feature_indices=self.discriminator.feature_indices,
-                )
-
-                real_feat, t_real = self._compute_real_feat(real_data=real_data, t=t, eps=eps, condition=condition)
+            fake_feat = self.fake_score(
+                x_t_sg,
+                t,
+                condition=condition,
+                return_features_early=True,
+                feature_indices=self.discriminator.feature_indices,
+            )
+            real_feat, t_real = self._compute_real_feat(real_data=real_data, t=t, eps=eps, condition=condition)
 
             real_feat_logit = self.discriminator(real_feat)
             gan_loss_disc = gan_loss_discriminator(real_feat_logit, self.discriminator(fake_feat))


### PR DESCRIPTION
I really appreciate the amazing work of bringing together multiple distillation methods into a single unified framework. 
While looking through the DMD2 implementation in FastGen, I noticed what seems to be a slight discrepancy from the original paper and reference implementation, so I wanted to submit this PR.

This PR updates DMD2 so that GAN losses use fake_score features instead of teacher features.

Changes:
- use `fake_score` features for generator GAN loss
- use `fake_score` features for discriminator real/fake inputs
- use `fake_score` features in the R1 perturbation path
- allow discriminator-side adversarial gradients to also update the `fake_score` backbone

`teacher` remains responsible for producing the x0 target used by VSD.

This change is motivated by the DMD2 paper and its reference implementations. 
In Section 4.3 of *Improved Distribution Matching Distillation for Fast Image Synthesis* (NeurIPS 2024), the authors write:

> "Our integration of a GAN classifier into DMD follows a minimalist design: we add a classification branch on top of the bottleneck of the fake diffusion denoiser (see Fig. 3)."

This is also consistent with existing implementations:
- Original DMD2 applies the classification head on `fake_unet` bottleneck features:
  https://github.com/tianweiy/DMD2/blob/8d8fa55633d47cfb81bbc7a892e7248f9518763f/main/edm/edm_guidance.py#L185
- NVIDIA Cosmos DMD2 similarly routes the adversarial path through `fake_score` intermediate features:
  https://github.com/nvidia-cosmos/cosmos-predict2.5/blob/7e5ffc83fefb2ae1c105c1185cdeb239efb1325c/cosmos_predict2/_src/predict2/distill/models/video2world_model_distill_dmd2.py#L244

If the current use of `teacher` features was intentional, I’d appreciate clarification on the intended design.