### PR TITLE
fix: guidance scale 5.0 contradicts comment stating official value 8

### DIFF
--- a/fastgen/configs/experiments/CosmosPredict2/config_sft_v2w.py
+++ b/fastgen/configs/experiments/CosmosPredict2/config_sft_v2w.py
@@ -16,7 +16,7 @@ def create_config():
     config.model.net.is_video2world = True
     config.model.net.num_conditioning_frames = 1
     # Official post-trained Video2World inference uses guidance scale 8
-    config.model.guidance_scale = 5.0
+    config.model.guidance_scale = 8.0
 
     config.log_config.group = "cosmos_predict2_sft_v2w"
 


### PR DESCRIPTION
### Problem
fix: guidance scale 5.0 contradicts comment stating official value 8

### Fix
Replace:
```
    # Official post-trained Video2World inference uses guidance scale 8
    config.model.guidance_scale = 5.0
```

with:
```
    # Official post-trained Video2World inference uses guidance scale 8
    config.model.guidance_scale = 8.0
```

### Files changed
- `fastgen/configs/experiments/CosmosPredict2/config_sft_v2w.py`